### PR TITLE
feat(contestant): Include bank details in contestant query

### DIFF
--- a/src/modules/v1/contestant/contestant.service.ts
+++ b/src/modules/v1/contestant/contestant.service.ts
@@ -139,7 +139,25 @@ export class ContestantService {
                     equipmentOwned: true,
                     shirtSize: true,
                     storeAddress: true,
-                    tournament: true,
+                    tournament: {
+                        select: {
+                            price: true,
+                            usingLogoPrice: true,
+                            event: { // Include the related Event
+                                select: {
+                                    bank: { // Include the related Bank
+                                        select: {
+                                            id: true,
+                                            BankName: true,
+                                            BankType: true,
+                                            BankNo: true,
+                                            noHp: true,
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     optionPrice: true,
                     phoneNo: true,
                     contestantType: true,


### PR DESCRIPTION
Modify the contestant retrieval query to include bank information by traversing the `tournament -> event -> bank` relationship.

This change makes the event's bank details (name, type, account number) available when fetching a contestant's data, which is necessary for displaying payment instructions. The query is also optimized to select only the required fields, preventing over-fetching of the entire tournament object.